### PR TITLE
Enable renovate to pin Actions to sha1 and semver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "pre-commit": {
     "enabled": true


### PR DESCRIPTION
So e.g. `actions/checkout@v4` is update to `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`

For more context see:

* Enable pinDigest to convert a major version to semver renovatebot/renovate#21901
* https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver

Protects against attacks where version tags get mutated to point to malicious code to e.g. extract secrets via gh accounts be compromised.